### PR TITLE
Update controlCMD.R

### DIFF
--- a/R/controlCMD.R
+++ b/R/controlCMD.R
@@ -28,7 +28,8 @@ function(port)
 # connections and readBin with raw data, see:
 # http://www.mail-archive.com/r-devel@r-project.org/msg16420.html.
 # we force blocking connections on Windows systems.
-  if(Sys.info()[[1]] == "Windows")
+# Also seems to happen in Mac OS X
+  if(Sys.info()[[1]] == "Windows" || Sys.info()[[1]] == "Darwin")
     .iqEnv$con[port][[1]] <- socketConnection(.iqEnv$host, .iqEnv$ports[port][[1]],open='a+b', blocking=TRUE)
   else
     .iqEnv$con[port][[1]] <- socketConnection(.iqEnv$host, .iqEnv$ports[port][[1]],open='a+b')


### PR DESCRIPTION
Added blocking connections to Mac OS X because they seem to suffer from the same blocking problem as Windows.
